### PR TITLE
Allow any number to be dialed

### DIFF
--- a/apptest/launchTest.sh
+++ b/apptest/launchTest.sh
@@ -1,9 +1,8 @@
 #! /bin/bash
 
-PROJECT_ID=$(curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/project/project-id)
 IP=$(getent hosts ${HOST} | head -n 1 | awk '{ print $1 }')
 
-node index.js --svc "${PROJECT_ID}" --host "${IP}"
+node index.js --svc "1234567890" --host "${IP}"
 
 RESULT=$?
 

--- a/telephony-bridge/etc_asterisk/extensions.conf
+++ b/telephony-bridge/etc_asterisk/extensions.conf
@@ -11,7 +11,7 @@ exten => test,1,Answer()
 exten => _[a-z0-9].,1,NoOp(Dialogflow)
  same =>   n,Answer
  same =>   n,SpeechCreate()
- same =>   n,Set(SPEECH_ENGINE(project_id)=${EXTEN})
+ same =>   n,Set(SPEECH_ENGINE(project_id)=${PROJECT_ID})
  same =>   n,Set(SPEECH_ENGINE(session_id)=${UNIQUEID})
  same =>   n,Set(SPEECH_ENGINE(language)=${CHANNEL(language)})
  same =>   n,Set(LANG_OVERRIDE=${PJSIP_HEADER(read,Language)})

--- a/telephony-bridge/etc_asterisk/pjsip.conf
+++ b/telephony-bridge/etc_asterisk/pjsip.conf
@@ -21,3 +21,4 @@ force_rport=yes
 rewrite_contact=yes
 transport=transport-udp-nat
 direct_media=no
+set_var=PROJECT_ID=${PROJECT_ID}


### PR DESCRIPTION
Determine the project ID on startup for the switch container
so users can just dial anything and be connected.
As a result, no longer have to do this in the tester.
So change the tester to test this.