### PR TITLE
Fix application descriptor

### DIFF
--- a/manifest/application.yaml.template
+++ b/manifest/application.yaml.template
@@ -23,57 +23,57 @@ spec:
     kind: Secret
   - group: v1
     kind: Service
-descriptor:
-  type: Dialogflow Enterprise Telephony Gateway
-  version: '1.0'
-  description: |-
-    The USAN Dialogflow Enterprise Telephony Gateway allows Google Dialogflow Enterprise users to easily 
-    connect to their projects from existing phone numbers and enterprise telephony networks. The solution 
-    connects to corporate PBXs and SBCs via SIP/RTP and provides a bridging gateway function into the Google 
-    Dialogflow Enterpirse voice API. The solution proivdes the necessary services to enable managing the end 
-    pointing of the voice on the RTP circuit, forwarding the voice utterances to Dialogflow Enterprise, managing 
-    playing of voice files to the RTP circuit, and managing the transfers back to the Corporate Telephony network via SIP.
-  maintainers:
-  - name: USAN, Inc.
-    url: https://www.usan.com/google/dfetg
-  links:
-  - description: Getting Started
-    url: https://www.usan.com/google/dfetg
-  notes: |-
-    # Expose Gateway SIP port
-
-    By default, the gateway sets up a service for the RTP traffic on ports 10000-10100
-    but does not expose the SIP port. It is **highly recommended** that you add source filtering
-    or other traffic filter on this external address prior to exposing the SIP port.
-
-    To add a source filter, put your address (in CIDR format) into the gateway service as a source range:
-
-    ```
-    kubectl patch svc "$name-dfe-switch-svc" \
+  descriptor:
+    type: Dialogflow Enterprise Telephony Gateway
+    version: '1.0'
+    description: |-
+      The USAN Dialogflow Enterprise Telephony Gateway allows Google Dialogflow Enterprise users to easily 
+      connect to their projects from existing phone numbers and enterprise telephony networks. The solution 
+      connects to corporate PBXs and SBCs via SIP/RTP and provides a bridging gateway function into the Google 
+      Dialogflow Enterpirse voice API. The solution proivdes the necessary services to enable managing the end 
+      pointing of the voice on the RTP circuit, forwarding the voice utterances to Dialogflow Enterprise, managing 
+      playing of voice files to the RTP circuit, and managing the transfers back to the Corporate Telephony network via SIP.
+    maintainers:
+    - name: USAN, Inc.
+      url: https://www.usan.com/google/dfetg
+    links:
+    - description: Getting Started
+      url: https://www.usan.com/google/dfetg
+    notes: |-
+      # Expose Gateway SIP port
+      
+      By default, the gateway sets up a service for the RTP traffic on ports 10000-10100
+      but does not expose the SIP port. It is **highly recommended** that you add source filtering
+      or other traffic filter on this external address prior to exposing the SIP port.
+      
+      To add a source filter, put your address (in CIDR format) into the gateway service as a source range:
+      
+      ```
+      kubectl patch svc "$name-dfe-switch-svc" \
       --namespace "$namespace" \
       -p '{"spec":{"loadBalancerSourceRanges":["1.2.3.4/32"]}}'
-    ```
-
-    Then, run the following command to expose the SIP port on your gateway:
-
-    ```
-    kubectl patch svc "$name-dfe-switch-svc" \
+      ```
+      
+      Then, run the following command to expose the SIP port on your gateway:
+      
+      ```
+      kubectl patch svc "$name-dfe-switch-svc" \
       --namespace "$namespace" \
       -p '{"spec":{"ports":[{"port":5060,"targetPort":5060, \
-        "protocol":"UDP","name":"sip-port"}]}}'
-    ```
-
-    # Access Gateway
-
-    Retrieve the external IP of the Gateway service by running:
-
-    ```
-    kubectl get --namespace ${namespace} \
+      "protocol":"UDP","name":"sip-port"}]}}'
+      ```
+      
+      # Access Gateway
+      
+      Retrieve the external IP of the Gateway service by running:
+      
+      ```
+      kubectl get --namespace ${namespace} \
       svc ${name}-dfe-switch-svc \
       -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
-    ```
-
-    Note that it might take some time for the external IP to be provisioned.
-
-    Place a SIP call to `${PROJECT_ID}@${SERVICE_IP}:5060` to access Dialogflow through the Gateway.
-    
+      ```
+      
+      Note that it might take some time for the external IP to be provisioned.
+      
+      Place a SIP call to `some extension@service ip:5060` (any extension but test) to access Dialogflow through the Gateway.
+      Place a SIP call to `test@$service ip:5060` to test audio connectivity.


### PR DESCRIPTION
In migrating to v1beta1 the descriptor had been put at the top level. It should be a child of schema.

While here, fix the instructions on how to connect (no longer need project id) and add some copy about test@ip being a test endpoint.